### PR TITLE
use config flie to specify message packages

### DIFF
--- a/turtle_teleop_rclex/README.md
+++ b/turtle_teleop_rclex/README.md
@@ -2,25 +2,6 @@
 ターミナルのキー入力から`/turtle1/cmd_vel`トピックへturtlesimの制御情報を出版
 
 ## 準備
-- Rclexをcloneし`v0.6.0`にcheckout
-```shell
-$ git clone https://github.com/rclex/rclex.git
-$ cd rclex
-$ git checkout v0.6.0
-```
-- `rclex/packages.txt`を編集してメッセージ型を指定
-```
-geometry_msgs/msg/Twist
-turtlesim/msg/Pose
-```
-- `mix.exs`でRclexのパスを指定
-```elixir
-def deps do
-  [
-    {:rclex, path: "../../rclex"}
-  ]
-end
-```
 - rubyのインストール
 ```shell
 $ apt install ruby

--- a/turtle_teleop_rclex/config/config.exs
+++ b/turtle_teleop_rclex/config/config.exs
@@ -1,0 +1,8 @@
+import Config
+
+config :rclex, :message_packages,
+  [
+    "std_msgs/msg/String",
+    "geometry_msgs/msg/Twist",
+    "turtlesim/msg/Pose",
+  ]

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -3,7 +3,7 @@ defmodule TurtleTeleopRclex.TeleopKey do
     context = Rclex.rclexinit()
     {:ok, nodename} = Rclex.ResourceServer.create_singlenode(context, 'teleop_ex')
     {:ok, publisher_id} = Rclex.Node.create_single_publisher(nodename, 'GeometryMsgs.Msg.Twist', 'turtle1/cmd_vel')
-    IO.write("Use W|A|S|D|X keys to move the turtle. Quit 'Q' to quit.")
+    IO.puts("Use W|A|S|D|X keys to move the turtle. Quit 'Q' to quit.")
     teleop_loop(publisher_id)
   end
 

--- a/turtle_teleop_rclex/mix.exs
+++ b/turtle_teleop_rclex/mix.exs
@@ -21,7 +21,8 @@ defmodule TurtleTeleopRclex.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:rclex, path: "../../rclex"}
+      # {:rclex, path: "../../rclex", override: false}
+      {:rclex, git: "https://github.com/rclex/rclex.git", branch: "config_msgpkg"}
     ]
   end
 end

--- a/turtle_teleop_rclex/mix.exs
+++ b/turtle_teleop_rclex/mix.exs
@@ -22,7 +22,7 @@ defmodule TurtleTeleopRclex.MixProject do
   defp deps do
     [
       # {:rclex, path: "../../rclex", override: false}
-      {:rclex, git: "https://github.com/rclex/rclex.git", branch: "config_msgpkg"}
+      {:rclex, "~> 0.6.1"}
     ]
   end
 end

--- a/turtle_teleop_rclex/mix.lock
+++ b/turtle_teleop_rclex/mix.lock
@@ -1,3 +1,4 @@
 %{
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
+  "rclex": {:git, "https://github.com/rclex/rclex.git", "d1653d5a8f4cd2bd648c94253da839edc0c0d4a7", [branch: "config_msgpkg"]},
 }

--- a/turtle_teleop_rclex/mix.lock
+++ b/turtle_teleop_rclex/mix.lock
@@ -1,4 +1,5 @@
 %{
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "rclex": {:git, "https://github.com/rclex/rclex.git", "d1653d5a8f4cd2bd648c94253da839edc0c0d4a7", [branch: "config_msgpkg"]},
+  "rclex": {:hex, :rclex, "0.6.1", "396271b4a8d70f92abdb0ed9e14f748630fc484f78d2446a4b0ebfbad050aec6", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:rclex_gen_msgs, "~> 0.1.0", [hex: :rclex_gen_msgs, repo: "hexpm", optional: false]}], "hexpm", "67d7e2d4eb663353217f9c3b7a5a8c883d048544833127d462725838c029b2ea"},
+  "rclex_gen_msgs": {:hex, :rclex_gen_msgs, "0.1.0", "265c9dc6a5e820e12a669d3c5eedcaf1a89d340f93b99ae6f5505a610850cc92", [:mix], [], "hexpm", "a6b190dcfb98d45452eeab4145250f9ea4ed65444bf4a146cbe5ed704ae625fb"},
 }


### PR DESCRIPTION
- メッセージ型の指定をconfigファイルにて行うようにし，rclexのv0.6.1に対応しました．
- hex.pmのrclexを依存パッケージとして指定するようにしました．
- 従来通りの動作を確認済みです．