### PR TITLE
Suggest to add docker-compose.yml to try example easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,29 @@ Examples for Rclex
  - Rclex_many_talker   : multi nodes talker
  - turtle_teleop_rclex : key input to turtle_sim sample
  - turtle_pose_phoenix : turtle topic web visualizer
+
+
+# how to try example
+
+```
+$ cd your_woking_directry
+$ git clone https://github.com/rclex/rclex_examples.git
+$ cd rclex_examples/
+$ docker compose run --rm rclex_docker /bin/bash
+# inside container, change directory example one, this time `rclex_listener`
+root@************:/# cd /root/rclex_examples/rclex_listener/
+root@************:~/rclex_examples/rclex_listener# mix deps.get
+...
+# try example function
+root@************:~/rclex_examples/rclex_listener# iex -S mix
+iex(1)> RclexListener.subscribe_message
+
+12:38:12.341 [debug] JobExecutor start
+
+12:38:12.344 [debug] listener/chatter/sub subscriber process start
+
+12:38:22.352 [debug] subscriber finished: listener/chatter/sub
+
+12:38:22.353 [debug] finish node: listener
+{:ok, #Reference<0.2781152389.209059862.173351>}
+```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Examples for Rclex
  - turtle_teleop_rclex : key input to turtle_sim sample
  - turtle_pose_phoenix : turtle topic web visualizer
 
+## How to try examples
 
-# how to try example
+Let's get a quick start for [rclex](https://github.com/rclex/rclex) using the Docker environment!
 
 ```
 $ cd your_woking_directry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+    rclex_docker:
+        build: .
+        image: rclex/rclex_docker:${TAG:-latest}
+        volumes:
+            - .:/root/rclex_examples/
+        tty: true

--- a/rclex_listener/mix.exs
+++ b/rclex_listener/mix.exs
@@ -5,7 +5,7 @@ defmodule RclexListener.MixProject do
     [
       app: :rclex_listener,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/rclex_many_listeners/mix.exs
+++ b/rclex_many_listeners/mix.exs
@@ -5,7 +5,7 @@ defmodule RclexManyListeners.MixProject do
     [
       app: :rclex_many_listeners,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/rclex_many_talkers/mix.exs
+++ b/rclex_many_talkers/mix.exs
@@ -5,7 +5,7 @@ defmodule RclexManyTalkers.MixProject do
     [
       app: :rclex_many_talkers,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
タイトルままです。

example を簡単に試すことができるよう docker-compose.yml の追加を提案します。

