### PR TITLE
improve turtle_teleop_rclex application

### DIFF
--- a/turtle_teleop_rclex/README.md
+++ b/turtle_teleop_rclex/README.md
@@ -1,11 +1,6 @@
 # TurtleTeleopRclex
 ターミナルのキー入力から`/turtle1/cmd_vel`トピックへturtlesimの制御情報を出版
 
-## 準備
-- rubyのインストール
-```shell
-$ apt install ruby
-```
 ## 使い方
 - turtlesimを起動しておく
 ```shell

--- a/turtle_teleop_rclex/README.md
+++ b/turtle_teleop_rclex/README.md
@@ -1,36 +1,79 @@
 # TurtleTeleopRclex
+
+teleoperation for turtle_sim from the key input
+
+## Description
+
+This example offers the teleoperation of [turtlesim_node](https://docs.ros.org/en/foxy/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.html), 
+that is the most famous examle in ROS community.
+
+The Rclex node `teleop_ex` publishes Twist (`geometry_msgs/msg/Twist`) message to `/turtle1/cmd_vel` topic according to the key input on the console.  
+In addition,`subpose_ex` subscribes Pose (`turtlesim/msg/Pose`) message from `/turtle1/pose` topic, and casts its data to `:pose_server` implemented by GenServer (this value can be visualized by [turtle_pose_phoenix](../turtle_pose_phoenix)) connected with Erlang Node.
+
 ターミナルのキー入力から`/turtle1/cmd_vel`トピックへturtlesimの制御情報を出版
 
-## 使い方
-- turtlesimを起動しておく
-```shell
-$ ros2 run turtlesim turtlesim_node
+## Operation
+
+### Building
+
 ```
-### Teleop
-- `start_teleop`関数を実行
-```shell
-$ mix run -e "TurtleTeleopRclex.TeleopKey.start_teleop"
+source /opt/ros/foxy/setup.bash
+mix deps.get
+mix rclex.gen.msgs
+mix compile
 ```
-- W|A|S|D|Xキーで移動・回転，Qキーで終了
-  - W:前進
-  - A:左回転
-  - S:静止
-  - D:右回転
-  - X:後退
-### Poseの購読
-- `rclex_examples/turtle_pose_phoenix`からPhoenixを起動
-```shell
-~/rclex_examples/turtle_pose_phoenix$ iex --name node1@[ip_address] --cookie c2e -S mix phx.server
-iex(node1@[ip_address])1>
+
+### Execution
+
+#### Teleoperation from key input
+
+First of all, please run turtlesim_node on the other terminal.
+
 ```
-- `rclex_examples/turtle_teleop_rclex`からiexを起動
-```shell
-~/rclex_examples/turtle_teleop_rclex$ iex --name node2@[ip_address] --cookie c2e -S mix
-iex(node2@[ip_address])1>
+source /opt/ros/foxy/setup.bash
+ros2 run turtlesim turtlesim_node
 ```
-- `Node.connect(:"node1@[ip_address]")`を実行
-- node2で`TurtleTeleopRclex.Pose.start_pose/1`を実行
-  - 引数はxy座標情報を{:global, :turtle}に送信する間隔
-```shell
-iex(node2@[ip_address])1> TurtleTeleopRclex.Pose.start_pose(500)
+
+Then, please execute `TeleopKey.start_teleop/0` on IEx.
+
+```
+$ iex -S mix
+iex()> TurtleTeleopRclex.TeleopKey.start_teleop
+```
+
+The key input and operation corresponds to the following.
+
+- W: forward
+- A: turn left
+- D: turn right
+- X: backward
+- S: stop
+- Q: quit teleopration
+
+You can confirm "turtle" will move according to the key input!
+
+#### Subsription of pose
+
+First of all, please execute phoenix server from `rclex_examples/turtle_pose_phoenix`, along with turtlesim_node. 
+`[ip_address]` means IP address for your machine to configure the setting of Erlang Node.
+
+```
+$ cd rclex_examples/turtle_pose_phoenix
+$ iex --name node1@[ip_address] --cookie c2e -S mix phx.server
+iex(node1@[ip_address])> 
+```
+
+Also, please run IEx for turtle_teleop_rclex (this project) with the setting of Erlang Node.
+
+```
+$ cd rclex_examples/turtle_teleop_rclex
+$ iex --name node2@[ip_address] --cookie c2e -S mix
+iex(node2@[ip_address])> 
+```
+
+Then, please connect Nodes, and run `Pose.start_pose/1` (argument refers to the interval for casting the pose value to the GenServer).
+
+```
+iex(node2@[ip_address])> Node.connect(:"node1@[ip_address]")
+iex(node2@[ip_address])> TurtleTeleopRclex.Pose.start_pose(500)
 ```

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -18,10 +18,10 @@ defmodule TurtleTeleopRclex.TeleopKey do
       IO.gets("Input 'W|A|D|X|S' keys to move the turtle. Quit 'Q' to quit: ") |> String.trim()
 
     if cmd == "q" do
-      IO.puts("quit key was pressed.")
+      IO.puts("Quit key was pressed.")
     else
       case twist_get(cmd) do
-        nil -> ""
+        nil -> IO.puts("Input key is invalid, so ignored.")
         twist -> twist_pub(twist, publisher)
       end
 

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -29,9 +29,6 @@ defmodule TurtleTeleopRclex.TeleopKey do
     end
   end
 
-  defp twist_pub(nil, _) do
-  end
-
   defp twist_pub(data, publisher) do
     msg = Rclex.Msg.initialize('GeometryMsgs.Msg.Twist')
     Rclex.Msg.set(msg, data, 'GeometryMsgs.Msg.Twist')

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -10,7 +10,7 @@ defmodule TurtleTeleopRclex.TeleopKey do
     teleop_loop(publisher_id)
   end
 
-  def teleop_loop(publisher_id) do
+  defp teleop_loop(publisher_id) do
     getch()
     |> twist_get
     |> twist_pub(publisher_id)
@@ -18,7 +18,7 @@ defmodule TurtleTeleopRclex.TeleopKey do
     teleop_loop(publisher_id)
   end
 
-  def getch do
+  defp getch do
     ruby_cmd = ~S"""
       ruby -e '
         require "io/console"
@@ -36,44 +36,44 @@ defmodule TurtleTeleopRclex.TeleopKey do
     end
   end
 
-  def twist_pub(nil, _) do
+  defp twist_pub(nil, _) do
   end
 
-  def twist_pub(data, publisher_id) do
+  defp twist_pub(data, publisher_id) do
     msg = Rclex.Msg.initialize('GeometryMsgs.Msg.Twist')
     Rclex.Msg.set(msg, data, 'GeometryMsgs.Msg.Twist')
     Rclex.Publisher.publish([publisher_id], [msg])
   end
 
-  def twist_get("w") do
+  defp twist_get("w") do
     twist_set(2.0, 0.0, 0.0, 0.0, 0.0, 0.0)
   end
 
-  def twist_get("a") do
+  defp twist_get("a") do
     twist_set(0.0, 0.0, 0.0, 0.0, 0.0, 2.0)
   end
 
-  def twist_get("s") do
+  defp twist_get("s") do
     twist_set(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
   end
 
-  def twist_get("d") do
+  defp twist_get("d") do
     twist_set(0.0, 0.0, 0.0, 0.0, 0.0, -2.0)
   end
 
-  def twist_get("x") do
+  defp twist_get("x") do
     twist_set(-2.0, 0.0, 0.0, 0.0, 0.0, 0.0)
   end
 
-  def twist_get("q") do
+  defp twist_get("q") do
     exit("quit key was pressed")
   end
 
-  def twist_get(_) do
+  defp twist_get(_) do
     nil
   end
 
-  def twist_set(linear_x, linear_y, linear_z, angular_x, angular_y, angular_z) do
+  defp twist_set(linear_x, linear_y, linear_z, angular_x, angular_y, angular_z) do
     %Rclex.GeometryMsgs.Msg.Twist{
       linear: %Rclex.GeometryMsgs.Msg.Vector3{x: linear_x, y: linear_y, z: linear_z},
       angular: %Rclex.GeometryMsgs.Msg.Vector3{x: angular_x, y: angular_y, z: angular_z}

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -6,7 +6,6 @@ defmodule TurtleTeleopRclex.TeleopKey do
     {:ok, publisher} =
       Rclex.Node.create_publisher(node, 'GeometryMsgs.Msg.Twist', 'turtle1/cmd_vel')
 
-    IO.puts("Input 'W|A|S|D|X' keys to move the turtle. Quit 'Q' to quit.")
     teleop_loop(publisher)
 
     Rclex.Node.finish_job(publisher)
@@ -15,7 +14,8 @@ defmodule TurtleTeleopRclex.TeleopKey do
   end
 
   defp teleop_loop(publisher) do
-    cmd = getch()
+    cmd =
+      IO.gets("Input 'W|A|S|D|X' keys to move the turtle. Quit 'Q' to quit: ") |> String.trim()
 
     if cmd == "q" do
       IO.puts("quit key was pressed.")
@@ -23,25 +23,9 @@ defmodule TurtleTeleopRclex.TeleopKey do
       twist_get(cmd)
       |> twist_pub(publisher)
 
+      # wait for publishing
+      Process.sleep(10)
       teleop_loop(publisher)
-    end
-  end
-
-  defp getch do
-    ruby_cmd = ~S"""
-      ruby -e '
-        require "io/console"
-        @output = IO.new(4)
-        @output.sync = true
-        char = STDIN.getch
-        @output.write(char)
-      '
-    """
-
-    port = Port.open({:spawn, ruby_cmd}, [:binary, :nouse_stdio])
-
-    receive do
-      {^port, {:data, result}} -> IO.inspect(result)
     end
   end
 

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -15,7 +15,7 @@ defmodule TurtleTeleopRclex.TeleopKey do
 
   defp teleop_loop(publisher) do
     cmd =
-      IO.gets("Input 'W|A|S|D|X' keys to move the turtle. Quit 'Q' to quit: ") |> String.trim()
+      IO.gets("Input 'W|A|D|X|S' keys to move the turtle. Quit 'Q' to quit: ") |> String.trim()
 
     if cmd == "q" do
       IO.puts("quit key was pressed.")

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -8,6 +8,10 @@ defmodule TurtleTeleopRclex.TeleopKey do
 
     IO.puts("Input 'W|A|S|D|X' keys to move the turtle. Quit 'Q' to quit.")
     teleop_loop(publisher)
+
+    Rclex.Node.finish_job(publisher)
+    Rclex.ResourceServer.finish_node(node)
+    Rclex.shutdown(context)
   end
 
   defp teleop_loop(publisher) do

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -11,11 +11,15 @@ defmodule TurtleTeleopRclex.TeleopKey do
   end
 
   defp teleop_loop(publisher_id) do
-    getch()
-    |> twist_get
-    |> twist_pub(publisher_id)
+    cmd = getch()
+    if cmd == "q" do
+      IO.puts("quit key was pressed.")
+    else
+      twist_get(cmd)
+      |> twist_pub(publisher_id)
 
-    teleop_loop(publisher_id)
+      teleop_loop(publisher_id)
+    end
   end
 
   defp getch do
@@ -63,10 +67,6 @@ defmodule TurtleTeleopRclex.TeleopKey do
 
   defp twist_get("x") do
     twist_set(-2.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-  end
-
-  defp twist_get("q") do
-    exit("quit key was pressed")
   end
 
   defp twist_get(_) do

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -1,24 +1,25 @@
 defmodule TurtleTeleopRclex.TeleopKey do
   def start_teleop do
     context = Rclex.rclexinit()
-    {:ok, nodename} = Rclex.ResourceServer.create_node(context, 'teleop_ex')
+    {:ok, node} = Rclex.ResourceServer.create_node(context, 'teleop_ex')
 
-    {:ok, publisher_id} =
-      Rclex.Node.create_publisher(nodename, 'GeometryMsgs.Msg.Twist', 'turtle1/cmd_vel')
+    {:ok, publisher} =
+      Rclex.Node.create_publisher(node, 'GeometryMsgs.Msg.Twist', 'turtle1/cmd_vel')
 
-    IO.puts("Use W|A|S|D|X keys to move the turtle. Quit 'Q' to quit.")
-    teleop_loop(publisher_id)
+    IO.puts("Input 'W|A|S|D|X' keys to move the turtle. Quit 'Q' to quit.")
+    teleop_loop(publisher)
   end
 
-  defp teleop_loop(publisher_id) do
+  defp teleop_loop(publisher) do
     cmd = getch()
+
     if cmd == "q" do
       IO.puts("quit key was pressed.")
     else
       twist_get(cmd)
-      |> twist_pub(publisher_id)
+      |> twist_pub(publisher)
 
-      teleop_loop(publisher_id)
+      teleop_loop(publisher)
     end
   end
 
@@ -43,10 +44,10 @@ defmodule TurtleTeleopRclex.TeleopKey do
   defp twist_pub(nil, _) do
   end
 
-  defp twist_pub(data, publisher_id) do
+  defp twist_pub(data, publisher) do
     msg = Rclex.Msg.initialize('GeometryMsgs.Msg.Twist')
     Rclex.Msg.set(msg, data, 'GeometryMsgs.Msg.Twist')
-    Rclex.Publisher.publish([publisher_id], [msg])
+    Rclex.Publisher.publish([publisher], [msg])
   end
 
   defp twist_get("w") do

--- a/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
+++ b/turtle_teleop_rclex/lib/turtle_teleop_rclex/teleop_key.ex
@@ -20,8 +20,10 @@ defmodule TurtleTeleopRclex.TeleopKey do
     if cmd == "q" do
       IO.puts("quit key was pressed.")
     else
-      twist_get(cmd)
-      |> twist_pub(publisher)
+      case twist_get(cmd) do
+        nil -> ""
+        twist -> twist_pub(twist, publisher)
+      end
 
       # wait for publishing
       Process.sleep(10)


### PR DESCRIPTION
turtle_teleop_rclex のソースを整理しました
- Rubyで getch してたやつをやめた see https://github.com/rclex/rclex_examples/commit/10d7579346a5fcd7ddddf96ecba6ae124398f53a and #16 
- quit するシーケンスを調整して，ちゃんと終了処理も書いた
- node, publisher の名前を他のサンプルと統一させた
- 公開しても意味ないやつは `defp` にした
- README をえいごかした see #13 
  - turtle_teleop_phoenix はそもそもこっちもソースから直したい気がするので，まだ英語化していない
  - というか phoenix 内で rclex 使えるのが確認できたら（改良できたら），こっちは pose の購読＆シリアル表示のみにするか消すかも？？

@s-hosoai 動作確認のち merging よろっ！